### PR TITLE
fix(BRV-815): prevent recursive json stringify of fontSize

### DIFF
--- a/client/src/hooks/ThemeContext.tsx
+++ b/client/src/hooks/ThemeContext.tsx
@@ -58,11 +58,12 @@ export const ThemeProvider = ({ initialTheme, children }) => {
     if (fontSize == null) {
       setFontSize('text-base');
       applyFontSize('text-base');
-      localStorage.setItem('fontSize', 'text-base');
+      localStorage.setItem('fontSize', JSON.stringify('text-base'));
       return;
     }
-    setFontSize(fontSize);
-    applyFontSize(fontSize);
+
+    setFontSize(JSON.parse(fontSize));
+    applyFontSize(JSON.parse(fontSize));
     // Reason: This effect should only run once, and `setFontSize` is a stable function
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
Why this fixes the bug?
Since it kept stringifying the font-size value but not parsing it back when reading it, it kept adding additional quotation marks around the string, after enough refreshes the value of the string exceeded the maximum size of a storage variable and crashed the frontend